### PR TITLE
Updated zip creation script to produce the folder structure actually wanted

### DIFF
--- a/.github/workflows/filesystem.yml
+++ b/.github/workflows/filesystem.yml
@@ -19,6 +19,11 @@ jobs:
 
     env:
       RELEASE_FILE: ${{matrix.shortname}}-${{github.event.release.tag_name || github.sha}}
+      ROOT_DIR: "picofx"
+      BOARD_DIR: "picofx/boards/${{matrix.board}}"
+      EXAMPLES_DIR: "picofx/examples/${{matrix.shortname}}"
+      LIBS_DIR: "picofx/lib_temp"
+      EX_DIR: "picofx/ex_temp"
 
     steps:
     - uses: actions/checkout@v4
@@ -26,17 +31,34 @@ jobs:
         submodules: true
         path: picofx
 
+    - name: "Assemble lib content"
+      shell: bash
+      run: |
+        mkdir -p ${{env.LIBS_DIR}}/lib
+        cp -v -r ${{env.ROOT_DIR}}/picofx ${{env.LIBS_DIR}}/lib
+        cp -v -r ${{env.BOARD_DIR}}/visible_libs/. ${{env.LIBS_DIR}}/lib
+        rm -v ${{env.LIBS_DIR}}/lib/picofx/README.md
+
+    - name: "Assemble example content"
+      shell: bash
+      run: |
+        mkdir -p ${{env.EXAMPLES_DIR}}
+        cp -v -r ${{env.EXAMPLES_DIR}}/. ${{env.EX_DIR}}
+        rm -v ${{env.EX_DIR}}/README.md
+        rm -v -r ${{env.EX_DIR}}/examples/audio/photon_sword
+        rm -v ${{env.EX_DIR}}/examples/audio/photon_sword.py
+
     - name: Libs .zip artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{env.RELEASE_FILE}}-libs-only
-        path: picofx/picofx
+        name: ${{env.RELEASE_FILE}}-libraries-only
+        path: picofx/lib_temp
 
     - name:  Examples .zip artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{env.RELEASE_FILE}}-examples-only
-        path: "picofx/examples/${{matrix.shortname}}"
+        path: "picofx/ex_temp"
 
     - name: Libs .zip release asset
       if: github.event_name == 'release'
@@ -44,9 +66,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        asset_path: picofx/picofx
+        asset_path: picofx/lib_temp
         upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}-libs-only
+        asset_name: ${{env.RELEASE_FILE}}-libraries-only
         asset_content_type: application/octet-stream
 
     - name: Examples .zip release asset
@@ -55,7 +77,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        asset_path: "picofx/examples/${{matrix.shortname}}"
+        asset_path: "picofx/ex_temp"
         upload_url: ${{github.event.release.upload_url}}
         asset_name: ${{env.RELEASE_FILE}}-examples-only
         asset_content_type: application/octet-stream


### PR DESCRIPTION
Updated the script so it now reflects the content that was included in the last releases, filtering out readme's etc.
The Photon Sword example is specifically excluded as it requires audio files we cannot ship on the product.