### PR TITLE
RGB emergency - Add support for RGB channel, and use button long press to toggle effect

### DIFF
--- a/examples/tiny_fx/examples/showcase/rescue_vehicle.py
+++ b/examples/tiny_fx/examples/showcase/rescue_vehicle.py
@@ -1,13 +1,33 @@
+from tiny_fx import TinyFX
+from picofx import ColourPlayer, MonoPlayer
+from picofx.colour import RGBBlinkFX, RED, YELLOW, GREEN, CYAN, BLUE, MAGENTA
+from picofx.mono import FlashSequenceFX, StaticFX
 
+"""
+Play an alternating flashing sequence on two of TinyFX's outputs,
+and the RGB channel, recreating the effect of rescue vehicle beacons.
+The other outputs are static for illuminated head and tail lights.
+
+Press "Boot" to exit the program.
+"""
+BLACK=(-1,0,0,0)
+ORANGE=(-1,205,94,28)
+# Constants
+EMERGENCY = COLOURS = [RED,RED,RED,RED,BLUE,BLUE,BLUE,BLUE]
+EMERGENCY_BLINK_SPEED = 8
+HAZARD = [ORANGE]
+HAZARD_BLINK_SPEED = 1
+
+# Variables
 tiny = TinyFX()                         # Create a new TinyFX object to interact with the board
 player = ColourPlayer(tiny.rgb)         # Create a new effect player to control TinyFX's RGB output
 monoplayer = MonoPlayer(tiny.outputs)
 
-# Create and set up an red blue flashing effect to play
+# Create and set up a rainbow effect to play
 player.effects = [
     RGBBlinkFX(colour=COLOURS,          # The colour (or colours to blink in sequence)
-                            phase=0.0,
-                            speed=EMERGENCY_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second (1/T)
+                            phase=0.0,  # The start time in the cycle (0-1)
+                            speed=EMERGENCY_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second
                             duty=0.5) 	# Amount of the cycle to be "on"
 ]
 

--- a/examples/tiny_fx/examples/showcase/rescue_vehicle.py
+++ b/examples/tiny_fx/examples/showcase/rescue_vehicle.py
@@ -1,3 +1,4 @@
+import time
 from tiny_fx import TinyFX
 from picofx import ColourPlayer, MonoPlayer
 from picofx.colour import RGBBlinkFX, RED, YELLOW, GREEN, CYAN, BLUE, MAGENTA
@@ -8,28 +9,35 @@ Play an alternating flashing sequence on two of TinyFX's outputs,
 and the RGB channel, recreating the effect of rescue vehicle beacons.
 The other outputs are static for illuminated head and tail lights.
 
-Press "Boot" to exit the program.
+Press "Boot" to exit the program, or long press to toggle RGB effects.
 """
-BLACK=(-1,0,0,0)
-ORANGE=(-1,205,94,28)
+
 # Constants
 EMERGENCY = COLOURS = [RED,RED,RED,RED,BLUE,BLUE,BLUE,BLUE]
 EMERGENCY_BLINK_SPEED = 8
+ORANGE = (228,114,28)
 HAZARD = [ORANGE]
-HAZARD_BLINK_SPEED = 1
+HAZARD_BLINK_SPEED = 1.8
 
 # Variables
 tiny = TinyFX()                         # Create a new TinyFX object to interact with the board
 player = ColourPlayer(tiny.rgb)         # Create a new effect player to control TinyFX's RGB output
 monoplayer = MonoPlayer(tiny.outputs)
 
-# Create and set up a rainbow effect to play
-player.effects = [
-    RGBBlinkFX(colour=COLOURS,          # The colour (or colours to blink in sequence)
-                            phase=0.0,  # The start time in the cycle (0-1)
-                            speed=EMERGENCY_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second
-                            duty=0.5) 	# Amount of the cycle to be "on"
-]
+# Create and set up an red blue flashing effect to play, and a hazard one for later
+rgbEffect = RGBBlinkFX(colour=COLOURS,  # The colour (or colours to blink in sequence)
+                       phase=0.0,       # The start time in the cycle (0-1)
+                       speed=EMERGENCY_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second (1/T)
+                       duty=0.5) 	    # Amount of the cycle to be "on"
+
+hazardEffect = RGBBlinkFX(colour=HAZARD,  # The colour (or colours to blink in sequence)
+                       phase=0.0,       # The start time in the cycle (0-1)
+                       speed=HAZARD_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second (1/T)
+                       duty=0.4) 	    # Amount of the cycle to be "on"
+
+player.effects = [rgbEffect]
+
+
 
 # Create a FlashSequenceFX effect for the beacon lights
 flashing = FlashSequenceFX(speed=1.0,   # The speed to flash at, with 1.0 being 1 second
@@ -56,13 +64,23 @@ player.pair(monoplayer)
 
 # Wrap the code in a try block, to catch any exceptions (including KeyboardInterrupt)
 try:
-    player.start()   # Start the effects running
-
-    # Loop until the effect stops or the "Boot" button is pressed
-    while player.is_running() and not tiny.boot_pressed():
-        pass
-
+    t = 0	# keep track of boot press duration
+    dont_exit_yet = True
+    while dont_exit_yet:
+        player.start()   # Start the effects running
+        
+        # Loop until the effect stops or the "Boot" button is pressed
+        while player.is_running() and not tiny.boot_pressed():
+            pass
+        t = time.ticks_ms()
+        while player.is_running() and tiny.boot_pressed():
+            pass
+        if time.ticks_ms() - t > 500:  	# long press - toggle effect
+            player.effects = [hazardEffect] if player.effects[0] is rgbEffect else [rgbEffect]
+        else:                         	# short press - exit
+            dont_exit_yet = False
 # Stop any running effects and turn off all the outputs
 finally:
     player.stop()
     tiny.shutdown()
+

--- a/examples/tiny_fx/examples/showcase/rescue_vehicle.py
+++ b/examples/tiny_fx/examples/showcase/rescue_vehicle.py
@@ -1,19 +1,15 @@
-from tiny_fx import TinyFX
-from picofx import MonoPlayer
-from picofx.mono import FlashSequenceFX, StaticFX
 
-"""
-Play an alternating flashing sequence on two of TinyFX's outputs,
-recreating the effect of rescue vehicle beacons.
-The other outputs are static for illuminated head and tail lights.
-
-Press "Boot" to exit the program.
-"""
-
-# Variables
 tiny = TinyFX()                         # Create a new TinyFX object to interact with the board
-player = MonoPlayer(tiny.outputs)       # Create a new effect player to control TinyFX's mono outputs
+player = ColourPlayer(tiny.rgb)         # Create a new effect player to control TinyFX's RGB output
+monoplayer = MonoPlayer(tiny.outputs)
 
+# Create and set up an red blue flashing effect to play
+player.effects = [
+    RGBBlinkFX(colour=COLOURS,          # The colour (or colours to blink in sequence)
+                            phase=0.0,
+                            speed=EMERGENCY_BLINK_SPEED, # The speed to cycle through colours at, with 1.0 being 1 second (1/T)
+                            duty=0.5) 	# Amount of the cycle to be "on"
+]
 
 # Create a FlashSequenceFX effect for the beacon lights
 flashing = FlashSequenceFX(speed=1.0,   # The speed to flash at, with 1.0 being 1 second
@@ -27,7 +23,7 @@ taillights = StaticFX(brightness=0.5)
 
 
 # Set up the mono effects to play. The first two are flashing, the rest are static
-player.effects = [
+monoplayer.effects = [
     flashing(0),
     flashing(1),
     headlights,
@@ -36,6 +32,7 @@ player.effects = [
     taillights
 ]
 
+player.pair(monoplayer)
 
 # Wrap the code in a try block, to catch any exceptions (including KeyboardInterrupt)
 try:


### PR DESCRIPTION
I've only got RGB LEDs 🎨 so this adds support for those, along with an orange hazard light mode if the boot button is long pressed rather than clicked.

The onboard RGB LED is also active so that's a nice touch (it's a lovely board - tinyfxw).

Maybe this is over the top, let me know, but it also serves as a useful example.

Also please do feel free to find a better orange, I randomly picked using browser dev tools and was totally unhappy with the result so starting abusing the rgb values 🤓 



Note to self:
Next I need to look at understanding the sequence functions better (checkout flashing(0)), or adding an easier way of having flashing RGB FX functions