### PR TITLE
Added an RGBFlicker FX

### DIFF
--- a/examples/tiny_fx/examples/effects/colour/flicker.py
+++ b/examples/tiny_fx/examples/effects/colour/flicker.py
@@ -1,0 +1,41 @@
+from tiny_fx import TinyFX
+from picofx import ColourPlayer
+from picofx.colour import RGBFlickerFX
+
+"""
+Play a flickering effect on one of TinyFX's RGB output.
+
+Press "Boot" to exit the program.
+"""
+
+# Constants
+COLOUR = (255, 128, 0)
+
+# Variables
+tiny = TinyFX()                     # Create a new TinyFX object to interact with the board
+player = ColourPlayer(tiny.rgb)         # Create a new effect player to control TinyFX's RGB output
+
+
+# Create and set up a flicker effect to play
+player.effects = RGBFlickerFX(colour=COLOUR,        # The colour that will be flickered
+                              brightness=1.0,       # The brightness to use when being bright (from 0.0 to 1.0)
+                              dimness=0.5,          # How much to dim the brightness by (from 0.0 to 1.0) when being dim
+                              bright_min=0.05,      # The min amount of time (in seconds) to be bright for
+                              bright_max=0.1,       # The max amount of time (in seconds) to be bright for
+                              dim_min=0.02,         # The min amount of time (in seconds) to be dim for
+                              dim_max=0.04)         # The max amount of time (in seconds) to be dim for
+
+
+
+# Wrap the code in a try block, to catch any exceptions (including KeyboardInterrupt)
+try:
+    player.start()   # Start the effects running
+
+    # Loop until the effect stops or the "Boot" button is pressed
+    while player.is_running() and not tiny.boot_pressed():
+        pass
+
+# Stop any running effects and turn off all the outputs
+finally:
+    player.stop()
+    tiny.shutdown()

--- a/picofx/colour/__init__.py
+++ b/picofx/colour/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from .blink import RGBBlinkFX
+from .flicker import RGBFlickerFX
 from .colour import RGBFX, HSVFX
 from .rainbow import RainbowFX, RainbowWaveFX
 from .step import HueStepFX
@@ -22,5 +23,6 @@ COLOUR_EFFECTS = [
     RainbowFX,
     RainbowWaveFX,
     HueStepFX,
-    RGBBlinkFX
+    RGBBlinkFX,
+    RGBFlickerFX
 ]

--- a/picofx/colour/flicker.py
+++ b/picofx/colour/flicker.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024 Christopher Parrott for Pimoroni Ltd
+#
+# SPDX-License-Identifier: MIT
+
+import random
+from picofx import Updateable
+
+
+class RGBFlickerFX(Updateable):
+    def __init__(self, colour=None, brightness=1.0, dimness=0.5, bright_min=0.05, bright_max=0.1, dim_min=0.02, dim_max=0.04):
+        if colour is None:
+            self.colour = (255, 0, 0)
+        if isinstance(colour, tuple) and len(colour) == 3:
+            self.colour = colour
+        else:
+            raise TypeError("colour is not a supported type. Expected a tuple of 3 numbers, or None.")
+        
+        self.brightness = brightness
+        self.dimness = dimness
+        self.bright_min = bright_min
+        self.bright_max = bright_max
+        self.dim_min = dim_min
+        self.dim_max = dim_max
+
+        self.__is_dim = False
+        self.__bright_dur = 0
+        self.__dim_dur = 0
+        self.__time = 0
+
+    def __call__(self):
+        return int(((self.brightness * (1.0 - self.dimness)) if self.__is_dim else self.brightness) * self.colour[0]), \
+               int(((self.brightness * (1.0 - self.dimness)) if self.__is_dim else self.brightness) * self.colour[1]), \
+               int(((self.brightness * (1.0 - self.dimness)) if self.__is_dim else self.brightness) * self.colour[2])
+
+    def tick(self, delta_ms):
+        self.__time += delta_ms
+
+        if self.__is_dim:
+            # Check if the dim duration has elapsed
+            if self.__time >= self.__dim_dur:
+                self.__time -= self.__dim_dur
+
+                self.__bright_dur = int(random.uniform(self.bright_min, self.bright_max) * 1000)
+                self.__is_dim = False
+
+        else:
+            # Only attempt to flicker if not in bright period
+            if self.__time >= self.__bright_dur:
+                self.__time -= self.__bright_dur
+
+                self.__dim_dur = int(random.uniform(self.dim_min, self.dim_max) * 1000)
+                self.__is_dim = True


### PR DESCRIPTION
This PR adds a simple variant of the FlickerFX class intended for the RGB LED. It behaves the same as the mono variant, with the additional parameter of a colour to flicker with. This does not change the colour as part of the flickering. This could be possible in the future, but for now is not required.